### PR TITLE
Simple gossip-based federation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +793,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,7 +834,19 @@ dependencies = [
  "serde",
  "sha2",
  "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -895,6 +922,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +989,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "percent-encoding"
@@ -1039,6 +1082,50 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -1267,6 +1354,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +1483,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +1579,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,7 +1614,19 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1502,6 +1636,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1556,6 +1720,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -1673,6 +1843,28 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,6 +1701,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,7 @@ tokio = { version = "1.44.2", features = [
     "rt",
     "rt-multi-thread",
 ] }
+tower-http = { version = "0.6.2", features = ["trace"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 url = { version = "2.5.4", features = [] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ tokio = { version = "1.44.2", features = [
 tower-http = { version = "0.6.2", features = ["trace"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-url = { version = "2.5.4", features = [] }
+url = { version = "2.5.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -36,12 +36,14 @@ See `mag --help` for a full list of commands and features.
 - [ ] `serve` - content-addressed file server
   - [x] GET content by CID
   - [x] Store-and-forward federation
-  - [ ] Simple gossip-based federation
   - [x] POST content to server
   - [x] Option to turn off POST
   - [ ] Option to require secret to POST
   - [ ] Option to encrypt content ala Magenc
   - [x] Logging (tracing)
+- [ ] Simple gossip-based federation
+  - [ ] Select n random peers and gossip updates to them
+  - [ ] Configurable CID deny list
 -  [ ] JS library for parsing/fetching magnetized links
 
 ## Magnet links

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See `mag --help` for a full list of commands and features.
   - [x] Option to turn off POST
   - [ ] Option to require secret to POST
   - [ ] Option to encrypt content ala Magenc
-  - [ ] Logging
+  - [x] Logging (tracing)
 -  [ ] JS library for parsing/fetching magnetized links
 
 ## Magnet links

--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ See `mag --help` for a full list of commands and features.
   - [ ] Option to encrypt content ala Magenc
   - [x] Logging (tracing)
 - [ ] Simple gossip-based federation
-  - [ ] Select n random peers and gossip updates to them
-  - [ ] Configurable CID deny list
+  - [x] Select n random peers and gossip updates to them
+  - [x] Configurable list of peers to notify
+  - [x] Configurable peer deny list
+  - [x] Configurable peer allow list
+  - [ ] Configurable CID block list
 -  [ ] JS library for parsing/fetching magnetized links
 
 ## Magnet links

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -3,7 +3,7 @@ use magnetize::cli::{Cli, Commands, Parser};
 use magnetize::magnet::MagnetLink;
 use magnetize::peers::read_peers;
 use magnetize::request::get_cid;
-use magnetize::server::{ServerState, serve};
+use magnetize::server::{ServerConfig, serve};
 use magnetize::url::Url;
 use std::collections::HashSet;
 use std::fs::{self, File};
@@ -34,8 +34,12 @@ fn main() {
                 }
                 None => Vec::new(),
             };
-            let state = ServerState::new(addr, dir, peers, post);
-            serve(state);
+            serve(ServerConfig {
+                addr,
+                dir,
+                peers,
+                allow_post: post,
+            });
         }
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -26,6 +26,7 @@ fn main() {
             addr,
             post,
             peers,
+            peering,
         } => {
             let peers = match peers {
                 Some(path) => {
@@ -38,6 +39,7 @@ fn main() {
                 addr,
                 dir,
                 peers,
+                peering,
                 allow_post: post,
             });
         }

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -10,7 +10,7 @@ const MULTIHASH_SHA256: u8 = 0x12;
 /// Represents a CIDv1 with SHA-256 hash using raw codec (0x55)
 /// The struct itself holds only the SHA-256 hash bytes.
 /// To get a CIDV1 bytes representation, use the `to_cid_bytes` method.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Cid([u8; 32]);
 
 impl Cid {

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -17,7 +17,7 @@ impl Cid {
     /// Parse a CIDv1 from bytes representing a CIDv1
     pub fn parse_bytes(cid_bytes: Vec<u8>) -> result::Result<Self, CidError> {
         if cid_bytes.len() != 36 {
-            return Err(CidError::ValueError("Invalid CID length".to_string()));
+            return Err(CidError::new("Invalid CID length"));
         }
 
         let version = cid_bytes[0];
@@ -30,7 +30,7 @@ impl Cid {
             || hash_algo != MULTIHASH_SHA256
             || hash_len != 32
         {
-            return Err(CidError::ValueError("Invalid CID format".to_string()));
+            return Err(CidError::new("Invalid CID format"));
         }
 
         // Create a fixed-size array from the hash slice
@@ -45,9 +45,8 @@ impl Cid {
     pub fn parse(cid_str: &str) -> result::Result<Self, CidError> {
         // Check if the CID starts with "b" (multicodec code for base32 lowercase encoded)
         if !cid_str.starts_with("b") {
-            return Err(CidError::ValueError(
-                "Invalid CID. CID must be multicodec base32 lowercase encoded (starts with 'b')"
-                    .to_string(),
+            return Err(CidError::new(
+                "Invalid CID. CID must be multicodec base32 lowercase encoded (starts with 'b')",
             ));
         }
         let cid_body = &cid_str[1..]; // drop the "b"
@@ -131,17 +130,19 @@ impl std::fmt::Display for Cid {
 }
 
 #[derive(Debug)]
-pub enum CidError {
-    DecodeError(data_encoding::DecodeError),
-    ValueError(String),
+pub struct CidError {
+    msg: String,
+}
+
+impl CidError {
+    pub fn new<S: Into<String>>(msg: S) -> Self {
+        CidError { msg: msg.into() }
+    }
 }
 
 impl std::fmt::Display for CidError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CidError::DecodeError(err) => write!(f, "Decode error: {}", err),
-            CidError::ValueError(err) => write!(f, "Value error: {}", err),
-        }
+        write!(f, "{}", self.msg)
     }
 }
 
@@ -149,7 +150,7 @@ impl std::error::Error for CidError {}
 
 impl From<data_encoding::DecodeError> for CidError {
     fn from(err: data_encoding::DecodeError) -> Self {
-        CidError::DecodeError(err)
+        CidError::new(err.to_string())
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,5 +50,10 @@ pub enum Commands {
         #[arg(help = "Allow file uploads via POST?")]
         #[arg(short = 'p', long = "post")]
         post: bool,
+
+        #[arg(
+            help = "Peers to gossip with. Reads peers from a file containing line-delimited URLs"
+        )]
+        peers: Option<PathBuf>,
     },
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,28 +60,26 @@ pub enum Commands {
 
         #[arg(
             long,
-            help = "Peers to gossip with. Reads peers from a file containing line-delimited URLs."
+            help = "Peers to send federation notifications to. File should contain line-delimited URLs."
         )]
-        peers: Option<PathBuf>,
+        notify: Option<PathBuf>,
 
         #[arg(
             long,
-            value_enum,
-            help = "Peering mode. Who to receive federated writes from?"
+            help = "Peers to allow federation notifications from. Notifications about peers in this list will be ignored. File should contain line-delimited URLs."
         )]
-        peering: Option<Peering>,
-    },
-}
+        deny: Option<PathBuf>,
 
-#[derive(Debug, clap::ValueEnum, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum Peering {
-    #[default]
-    #[value(
-        name = "trusted",
-        help = "Federate with trusted peers only. Use peers list both as a list to notify, and as an allow-list for who you will federate with."
-    )]
-    Trusted,
-    #[value(name = "all", help = "Federate with any and all peers")]
-    All,
+        #[arg(
+            long,
+            help = "Peers to allow federation notifications from. Notifications about peers that are not in this list will be ignored. File should contain line-delimited URLs."
+        )]
+        allow: Option<PathBuf>,
+
+        #[arg(
+            long,
+            help = "Allow federation from any peer? This flag overrides the allow list. However, peers in the deny list will still be ignored."
+        )]
+        allow_all: bool,
+    },
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,6 +55,13 @@ pub enum Commands {
         )]
         addr: String,
 
+        #[arg(
+            long,
+            help = "Public-facing URL of server. Used when sending peer notifications.",
+            value_name = "ADDRESS"
+        )]
+        url: String,
+
         #[arg(long, help = "Allow file uploads via POST?")]
         post: bool,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,6 @@ use data_encoding::DecodeError;
 #[derive(Debug)]
 pub enum Error {
     IoError(std::io::Error),
-    ValueError(String),
     DecodeError(DecodeError),
     MagnetLinkError(MagnetLinkError),
     RequestError(RequestError),
@@ -14,7 +13,6 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Error::ValueError(message) => write!(f, "ValueError: {}", message),
             Error::IoError(err) => write!(f, "IoError: {}", err),
             Error::DecodeError(err) => write!(f, "DecodeError: {}", err),
             Error::MagnetLinkError(err) => write!(f, "MagnetLinkError: {}", err),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cid;
 pub mod cli;
 pub mod error;
 pub mod magnet;
+pub mod peers;
 pub mod request;
 pub mod server;
 pub mod url;

--- a/src/peers.rs
+++ b/src/peers.rs
@@ -1,52 +1,79 @@
 use crate::url::Url;
+use std::fs::File;
 use std::io::{self, BufRead, BufReader, Read, Write};
+use std::path::Path;
 
-/// Read line-delimited URLs from a reader, such as an open file.
-pub fn read_peers<R: Read>(reader: R) -> Result<Vec<Url>, PeersError> {
+pub fn read_urls_from_lines<R: Read>(reader: R) -> Vec<Result<Url, UrlLinesError>> {
     let buf_reader = BufReader::new(reader);
-    let mut peers = Vec::new();
+    let mut results: Vec<Result<Url, UrlLinesError>> = Vec::new();
     for line in buf_reader.lines() {
-        let url = Url::parse(&line?)?;
-        peers.push(url);
+        let line = match line {
+            Ok(line) => line,
+            Err(err) => {
+                results.push(Err(UrlLinesError::from(err)));
+                continue;
+            }
+        };
+        let url = match Url::parse(&line) {
+            Ok(url) => Ok(url),
+            Err(err) => Err(UrlLinesError::from(err)),
+        };
+        results.push(url);
     }
-    Ok(peers)
+    results
 }
 
-/// Write line-delimited peers to a writer, such as an open file.
-pub fn write_peers<W: Write>(peers: &[Url], writer: &mut W) -> Result<(), PeersError> {
-    for peer in peers {
-        writeln!(writer, "{}", peer)?;
-    }
-    Ok(())
+/// Read line-delimited URLs from a file
+pub fn read_valid_urls_from_file<P: AsRef<Path>>(path: P) -> Result<Vec<Url>, io::Error> {
+    let file = File::open(path)?;
+    let urls = read_urls_from_lines(file)
+        .into_iter()
+        .filter_map(|res| match res {
+            Ok(url) => Some(url),
+            Err(err) => {
+                eprintln!("Error reading notify URL: {}", err);
+                None
+            }
+        })
+        .collect();
+    Ok(urls)
 }
 
 #[derive(Debug)]
-pub enum PeersError {
+pub enum UrlLinesError {
     IoError(io::Error),
     UrlError(url::ParseError),
 }
 
-impl std::fmt::Display for PeersError {
+impl std::fmt::Display for UrlLinesError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            PeersError::IoError(err) => write!(f, "IO error: {}", err),
-            PeersError::UrlError(err) => write!(f, "URL parse error: {}", err),
+            UrlLinesError::IoError(err) => write!(f, "IO error: {}", err),
+            UrlLinesError::UrlError(err) => write!(f, "URL parse error: {}", err),
         }
     }
 }
 
-impl std::error::Error for PeersError {}
+impl std::error::Error for UrlLinesError {}
 
-impl From<io::Error> for PeersError {
+impl From<io::Error> for UrlLinesError {
     fn from(err: io::Error) -> Self {
-        PeersError::IoError(err)
+        UrlLinesError::IoError(err)
     }
 }
 
-impl From<url::ParseError> for PeersError {
+impl From<url::ParseError> for UrlLinesError {
     fn from(err: url::ParseError) -> Self {
-        PeersError::UrlError(err)
+        UrlLinesError::UrlError(err)
     }
+}
+
+/// Write line-delimited peers to a writer, such as an open file.
+pub fn write_urls_to_lines<W: Write>(peers: &[Url], writer: &mut W) -> Result<(), io::Error> {
+    for peer in peers {
+        writeln!(writer, "{}", peer)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -55,11 +82,14 @@ mod tests {
     use std::io::Cursor;
 
     #[test]
-    fn test_read_peers() {
+    fn test_read_urls_from_lines() {
         let input = "http://example.com\nhttps://test.org\n";
         let reader = Cursor::new(input);
 
-        let peers = read_peers(reader).unwrap();
+        let peers: Vec<Url> = read_urls_from_lines(reader)
+            .into_iter()
+            .filter_map(|url| url.ok())
+            .collect();
 
         assert_eq!(peers.len(), 2);
         assert_eq!(peers[0].as_str(), "http://example.com/");
@@ -67,29 +97,27 @@ mod tests {
     }
 
     #[test]
-    fn test_read_peers_invalid_url() {
+    fn test_read_urls_from_lines_invalid_url() {
         let input = "not a valid url";
         let reader = Cursor::new(input);
 
-        let result = read_peers(reader);
+        let peers: Vec<Url> = read_urls_from_lines(reader)
+            .into_iter()
+            .filter_map(|url| url.ok())
+            .collect();
 
-        assert!(result.is_err());
-        if let Err(PeersError::UrlError(_)) = result {
-            // Expected error
-        } else {
-            panic!("Expected UrlError, got {:?}", result);
-        }
+        assert_eq!(peers.len(), 0);
     }
 
     #[test]
-    fn test_write_peers() {
+    fn test_write_urls_to_lines() {
         let mut output = Vec::new();
         let peers = vec![
             Url::parse("http://example.com").unwrap(),
             Url::parse("https://test.org").unwrap(),
         ];
 
-        write_peers(&peers, &mut output).unwrap();
+        write_urls_to_lines(&peers, &mut output).unwrap();
 
         let result = String::from_utf8(output).unwrap();
         assert_eq!(result, "http://example.com/\nhttps://test.org/\n");

--- a/src/peers.rs
+++ b/src/peers.rs
@@ -1,0 +1,97 @@
+use crate::url::Url;
+use std::io::{self, BufRead, BufReader, Read, Write};
+
+/// Read line-delimited URLs from a reader, such as an open file.
+pub fn read_peers<R: Read>(reader: R) -> Result<Vec<Url>, PeersError> {
+    let buf_reader = BufReader::new(reader);
+    let mut peers = Vec::new();
+    for line in buf_reader.lines() {
+        let url = Url::parse(&line?)?;
+        peers.push(url);
+    }
+    Ok(peers)
+}
+
+/// Write line-delimited peers to a writer, such as an open file.
+pub fn write_peers<W: Write>(peers: &[Url], writer: &mut W) -> Result<(), PeersError> {
+    for peer in peers {
+        writeln!(writer, "{}", peer)?;
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+pub enum PeersError {
+    IoError(io::Error),
+    UrlError(url::ParseError),
+}
+
+impl std::fmt::Display for PeersError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            PeersError::IoError(err) => write!(f, "IO error: {}", err),
+            PeersError::UrlError(err) => write!(f, "URL parse error: {}", err),
+        }
+    }
+}
+
+impl std::error::Error for PeersError {}
+
+impl From<io::Error> for PeersError {
+    fn from(err: io::Error) -> Self {
+        PeersError::IoError(err)
+    }
+}
+
+impl From<url::ParseError> for PeersError {
+    fn from(err: url::ParseError) -> Self {
+        PeersError::UrlError(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_read_peers() {
+        let input = "http://example.com\nhttps://test.org\n";
+        let reader = Cursor::new(input);
+
+        let peers = read_peers(reader).unwrap();
+
+        assert_eq!(peers.len(), 2);
+        assert_eq!(peers[0].as_str(), "http://example.com/");
+        assert_eq!(peers[1].as_str(), "https://test.org/");
+    }
+
+    #[test]
+    fn test_read_peers_invalid_url() {
+        let input = "not a valid url";
+        let reader = Cursor::new(input);
+
+        let result = read_peers(reader);
+
+        assert!(result.is_err());
+        if let Err(PeersError::UrlError(_)) = result {
+            // Expected error
+        } else {
+            panic!("Expected UrlError, got {:?}", result);
+        }
+    }
+
+    #[test]
+    fn test_write_peers() {
+        let mut output = Vec::new();
+        let peers = vec![
+            Url::parse("http://example.com").unwrap(),
+            Url::parse("https://test.org").unwrap(),
+        ];
+
+        write_peers(&peers, &mut output).unwrap();
+
+        let result = String::from_utf8(output).unwrap();
+        assert_eq!(result, "http://example.com/\nhttps://test.org/\n");
+    }
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,8 +1,8 @@
 use crate::cid::Cid;
 use crate::url::Url;
 use reqwest;
-
-pub type Client = reqwest::Client;
+pub use reqwest::Client;
+pub use reqwest::Response;
 
 pub fn build_client(timeout: std::time::Duration) -> Result<Client, reqwest::Error> {
     let client = reqwest::ClientBuilder::new().timeout(timeout).build()?;
@@ -11,11 +11,7 @@ pub fn build_client(timeout: std::time::Duration) -> Result<Client, reqwest::Err
 
 /// HEAD CID, to check if a CID exists at a URL
 /// Note that this function does not perform an integrity check, since HEAD requests do not include the body.
-pub async fn head_cid(
-    client: &Client,
-    url: &Url,
-    cid: &Cid,
-) -> Result<reqwest::Response, RequestError> {
+pub async fn head_cid(client: &Client, url: &Url, cid: &Cid) -> Result<Response, RequestError> {
     let cid_str = cid.to_string();
     let url = url.join(&cid_str)?;
     let response = client.head(url).send().await?;
@@ -47,10 +43,28 @@ pub async fn get_cid(client: &Client, url: &Url, cid: &Cid) -> Result<Vec<u8>, R
     Ok(body.to_vec())
 }
 
+/// Posts a notification to a URL, with CID and CDN headers.
+/// Returns the response.
+pub async fn post_notify(
+    client: &Client,
+    from: &Url,
+    to: &Url,
+    cid: &Cid,
+) -> Result<Response, RequestError> {
+    let response = client
+        .post(to.as_str())
+        .header("magnetize-peer", from.as_str())
+        .header("magnetize-cid", cid.to_string())
+        .send()
+        .await?;
+    Ok(response)
+}
+
 #[derive(Debug)]
 pub enum RequestError {
     RequestError(reqwest::Error),
     UrlParseError(url::ParseError),
+    InvalidHeaderValue(reqwest::header::InvalidHeaderValue),
     IntegrityError(String),
 }
 
@@ -59,6 +73,7 @@ impl std::fmt::Display for RequestError {
         match self {
             RequestError::RequestError(err) => write!(f, "Request Error: {}", err),
             RequestError::UrlParseError(err) => write!(f, "URL Parse Error: {}", err),
+            RequestError::InvalidHeaderValue(err) => write!(f, "Invalid Header Value: {}", err),
             RequestError::IntegrityError(err) => write!(f, "Integrity Error: {}", err),
         }
     }
@@ -69,6 +84,12 @@ impl std::error::Error for RequestError {}
 impl From<reqwest::Error> for RequestError {
     fn from(err: reqwest::Error) -> Self {
         RequestError::RequestError(err)
+    }
+}
+
+impl From<reqwest::header::InvalidHeaderValue> for RequestError {
+    fn from(err: reqwest::header::InvalidHeaderValue) -> Self {
+        RequestError::InvalidHeaderValue(err)
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,4 @@
 use crate::cid::Cid;
-use crate::cli::Peering;
 use crate::request::{self, Client};
 use crate::url::Url;
 use crate::util::random_choice;
@@ -10,35 +9,70 @@ use axum::{
     response::{IntoResponse, Response},
     routing::{get, head, post},
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use std::collections::HashSet;
 use std::{fs, io::Write};
 use std::{path::PathBuf, time::Duration};
 use tokio::sync::mpsc;
 use tower_http::trace::{self, TraceLayer};
 use tracing::Level;
+use url::Origin;
 
-// Define a notification task
-struct NotificationTask {
-    cid: Cid,
-    source_url: Url,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
 pub struct ServerConfig {
     /// The address the server should listen on
     pub addr: String,
     /// The directory where content-addressed files will be stored
     pub dir: PathBuf,
     pub allow_post: bool,
-    pub peers: Vec<Url>,
-    pub peering: Option<Peering>,
+    /// Allow federating with any peer?
+    pub allow_all: bool,
+    pub notify: Vec<Url>,
+    pub allow: HashSet<Origin>,
+    pub deny: HashSet<Origin>,
+}
+
+impl ServerConfig {
+    pub fn new(
+        addr: String,
+        dir: PathBuf,
+        allow_post: bool,
+        allow_all: bool,
+        notify: Vec<Url>,
+        allow: Vec<Url>,
+        deny: Vec<Url>,
+    ) -> Self {
+        ServerConfig {
+            addr,
+            dir,
+            allow_post,
+            allow_all,
+            notify,
+            allow: HashSet::from_iter(allow.into_iter().map(|url| url.origin())),
+            deny: HashSet::from_iter(deny.into_iter().map(|url| url.origin())),
+        }
+    }
 }
 
 #[derive(Clone)]
 struct ServerState {
-    pub config: ServerConfig,
+    config: ServerConfig,
     pub client: Client,
-    pub notification_sender: mpsc::Sender<NotificationTask>,
+    pub notification_sender: mpsc::Sender<NotifyTask>,
+}
+
+impl ServerState {
+    pub fn new(
+        config: ServerConfig,
+        client: Client,
+        notification_sender: mpsc::Sender<NotifyTask>,
+    ) -> Self {
+        ServerState {
+            config,
+            client,
+            notification_sender,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -85,21 +119,17 @@ pub async fn serve(config: ServerConfig) {
         .init();
 
     // Create message channel for background tasks
-    let (notification_sender, notification_receiver) = mpsc::channel::<NotificationTask>(1024);
+    let (notification_sender, notification_receiver) = mpsc::channel::<NotifyTask>(1024);
 
     // Create HTTP client
     let client =
         request::build_client(Duration::from_secs(2)).expect("Could not create HTTP client");
 
-    let address = config.addr.clone();
+    let addr = config.addr.clone();
     let worker_client = client.clone();
-    let worker_peers = config.peers.clone();
+    let worker_notify_peers = config.notify.clone();
 
-    let state = ServerState {
-        config,
-        notification_sender,
-        client,
-    };
+    let state = ServerState::new(config, client, notification_sender);
 
     // Build our application with routes
     let app = Router::new()
@@ -116,18 +146,18 @@ pub async fn serve(config: ServerConfig) {
         .with_state(state);
 
     // Spawn worker
-    tokio::spawn(notification_worker(
+    tokio::spawn(notify_worker(
         notification_receiver,
         worker_client,
-        worker_peers,
+        worker_notify_peers,
     ));
 
     // Run the server
-    let listener = tokio::net::TcpListener::bind(&address)
+    let listener = tokio::net::TcpListener::bind(&addr)
         .await
         .expect("Unable to bind server to address");
 
-    tracing::info!("listening on {}", &address);
+    tracing::info!(addr = &addr, "server listening");
 
     axum::serve(listener, app)
         .await
@@ -140,17 +170,24 @@ async fn sleep_jitter(max: Duration) {
     tokio::time::sleep(jitter).await;
 }
 
+// Task to notify a peer
+#[derive(Debug, Clone)]
+struct NotifyTask {
+    cid: Cid,
+    url: Url,
+}
+
 // Worker that processes background tasks
-async fn notification_worker(
-    mut receiver: mpsc::Receiver<NotificationTask>,
+async fn notify_worker(
+    mut receiver: mpsc::Receiver<NotifyTask>,
     client: reqwest::Client,
-    peers: Vec<Url>,
+    notify_peers: Vec<Url>,
 ) {
     tracing::info!("Notification worker started");
     // Process notifications until the channel is closed
     while let Some(task) = receiver.recv().await {
         // Select up to 12 random peers to notify
-        let selected_peers = random_choice(peers.clone(), 12);
+        let selected_peers = random_choice(notify_peers.clone(), 12);
 
         // Add some jitter (random delay) to spread out traffic spikes in the network and prevent congestion
         // See: <https://aws.amazon.com/builders-library/timeouts-retries-and-backoff-with-jitter/>
@@ -158,12 +195,20 @@ async fn notification_worker(
         sleep_jitter(Duration::from_millis(500)).await;
 
         for peer in selected_peers {
-            match request::post_notify(&client, &peer, &task.source_url, &task.cid).await {
+            match request::post_notify(&client, &peer, &task.url, &task.cid).await {
                 Ok(_) => {
-                    tracing::info!("Notified peer {} of {}", &peer, &task.cid);
+                    tracing::info!(
+                        peer = &peer.to_string(),
+                        cid = &task.cid.to_string(),
+                        "Notified peer"
+                    );
                 }
                 Err(err) => {
-                    tracing::info!("Failed to notify peer {}. Error: {}", &peer, err);
+                    tracing::info!(
+                        err = format!("{}", err),
+                        peer = peer.to_string(),
+                        "Failed to notify peer"
+                    );
                 }
             }
         }
@@ -242,6 +287,28 @@ async fn head_cid(State(state): State<ServerState>, Path(cid): Path<String>) -> 
     }
 }
 
+/// Should we notify this peer?
+/// - Deny list is always honored
+/// - Otherwise, notifications are restricted to allow list unless allow_all is true
+pub fn should_notify(
+    peer: &Url,
+    allow: &HashSet<url::Origin>,
+    deny: &HashSet<url::Origin>,
+    allow_all: bool,
+) -> bool {
+    let peer_origin = peer.origin();
+    // Always honor deny list
+    if deny.contains(&peer_origin) {
+        return false;
+    }
+    // If peer is not in the deny list, and we allow all, return true
+    if allow_all {
+        return true;
+    }
+    // Otherwise check against allow list
+    allow.contains(&peer_origin)
+}
+
 async fn post_notify(State(state): State<ServerState>, headers: HeaderMap) -> Response {
     // Get CID from request header
     let peer = match headers
@@ -260,7 +327,12 @@ async fn post_notify(State(state): State<ServerState>, headers: HeaderMap) -> Re
     };
 
     // If peer is not in the list of known peers, do nothing
-    if !state.config.peers.contains(&peer) {
+    if !should_notify(
+        &peer,
+        &state.config.allow,
+        &state.config.deny,
+        state.config.allow_all,
+    ) {
         return (StatusCode::BAD_REQUEST, "Untrusted peer").into_response();
     }
 
@@ -283,7 +355,7 @@ async fn post_notify(State(state): State<ServerState>, headers: HeaderMap) -> Re
 
     // Exit early if we already know about this CID
     if file_path.exists() {
-        return (StatusCode::OK, "").into_response();
+        return (StatusCode::OK, "Resource exists").into_response();
     }
 
     let Ok(url) = peer.join(&cid.to_string()) else {
@@ -306,11 +378,14 @@ async fn post_notify(State(state): State<ServerState>, headers: HeaderMap) -> Re
 
     // Add notification task to the queue
     // If queue is full, drop the task
-    if let Err(err) = state.notification_sender.try_send(NotificationTask {
+    if let Err(err) = state.notification_sender.try_send(NotifyTask {
         cid: cid.clone(),
-        source_url: url.clone(),
+        url: url.clone(),
     }) {
-        tracing::error!("Failed to queue notification task. Error: {}", err);
+        tracing::error!(
+            err = format!("{}", err),
+            "Failed to queue notification task"
+        );
     }
 
     // Return the CID
@@ -352,4 +427,56 @@ async fn post_file(State(state): State<ServerState>, mut multipart: Multipart) -
     }
 
     (StatusCode::BAD_REQUEST, "No file provided").into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_should_notify() {
+        let peer = Url::parse("https://example.com/resource").unwrap();
+        let peer2 = Url::parse("https://allowed.com/resource").unwrap();
+        let peer3 = Url::parse("https://denied.com/resource").unwrap();
+
+        let allow = HashSet::from_iter(vec![
+            url::Url::parse("https://allowed.com").unwrap().origin(),
+        ]);
+
+        let deny = HashSet::from_iter(vec![
+            url::Url::parse("https://denied.com").unwrap().origin(),
+        ]);
+
+        // Test with allow_all = true
+        assert!(
+            should_notify(&peer, &allow, &deny, true),
+            "When allow_all is true, non-denied peer should be notified"
+        );
+
+        assert!(
+            should_notify(&peer2, &allow, &deny, true),
+            "When allow_all is true, allowed peer should be notified"
+        );
+
+        assert!(
+            !should_notify(&peer3, &allow, &deny, true),
+            "When allow_all is true, denied peer should not be notified"
+        );
+
+        // Test with allow_all = false
+        assert!(
+            !should_notify(&peer, &allow, &deny, false),
+            "When allow_all is false, non-allowed peer should not be notified"
+        );
+
+        assert!(
+            should_notify(&peer2, &allow, &deny, false),
+            "When allow_all is false, allowed peer should be notified"
+        );
+
+        assert!(
+            !should_notify(&peer3, &allow, &deny, false),
+            "When allow_all is false, denied peer should not be notified"
+        );
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -21,19 +21,24 @@ pub struct ServerState {
     /// The directory where content-addressed files will be stored
     pub file_storage_dir: PathBuf,
     pub allow_post: bool,
-    pub feds: Vec<Url>,
+    pub peers: Vec<Url>,
     pub client: reqwest::Client,
 }
 
 impl ServerState {
-    pub fn new(address: String, file_storage_dir: PathBuf, allow_post: bool) -> Self {
+    pub fn new(
+        address: String,
+        file_storage_dir: PathBuf,
+        peers: Vec<Url>,
+        allow_post: bool,
+    ) -> Self {
         let client =
             request::build_client(Duration::from_secs(2)).expect("Could not create HTTP client");
         ServerState {
             address,
             file_storage_dir,
             allow_post,
-            feds: Vec::new(),
+            peers,
             client,
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,5 @@
 use crate::cid::Cid;
+use crate::cli::Peering;
 use crate::request::{self, Client};
 use crate::url::Url;
 use crate::util::random_choice;
@@ -30,6 +31,7 @@ pub struct ServerConfig {
     pub dir: PathBuf,
     pub allow_post: bool,
     pub peers: Vec<Url>,
+    pub peering: Option<Peering>,
 }
 
 #[derive(Clone)]

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,1 +1,8 @@
-pub use url::{ParseError, Url};
+use std::collections::HashSet;
+
+pub use url::{Origin, ParseError, Url};
+
+/// Returns a set of unique origins from a list of URLs.
+pub fn unique_origins(urls: &[Url]) -> HashSet<Origin> {
+    HashSet::from_iter(urls.iter().map(|url| url.origin()))
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+use rand::rng;
+use rand::seq::SliceRandom;
 use std::collections::HashMap;
 
 /// Group a list of key-value pairs into a HashMap of key-to-vector.
@@ -12,6 +14,14 @@ where
     });
 
     query
+}
+
+/// Choose up to `max` random elements from items, mutating original vector.
+pub fn random_choice<T>(mut items: Vec<T>, max: usize) -> Vec<T> {
+    let mut rng = rng();
+    items.shuffle(&mut rng);
+    items.truncate(max);
+    items
 }
 
 #[cfg(test)]
@@ -69,5 +79,42 @@ mod tests {
         );
         assert_eq!(result.get(&2), Some(&vec!["b".to_string()]));
         assert_eq!(result.get(&3), Some(&vec!["c".to_string()]));
+    }
+
+    #[test]
+    fn test_random_choice() {
+        let items = vec![
+            "http://example1.com",
+            "http://example2.com",
+            "http://example3.com",
+            "http://example4.com",
+            "http://example5.com",
+        ];
+
+        let selected = random_choice(items.to_owned(), 3);
+
+        assert_eq!(selected.len(), 3);
+        // Verify all selected peers are from the original list
+        for item in &selected {
+            assert!(items.contains(item));
+        }
+    }
+
+    #[test]
+    fn test_random_choice_with_max_greater_than_available() {
+        let items = vec!["http://example1.com", "http://example2.com"];
+
+        let selected = random_choice(items, 5);
+
+        assert_eq!(selected.len(), 2);
+    }
+
+    #[test]
+    fn test_random_choice_empty() {
+        let items: Vec<String> = vec![];
+
+        let selected = random_choice(items, 3);
+
+        assert!(selected.is_empty());
     }
 }


### PR DESCRIPTION
Simple gossip-based federation:

- POST `/notify` with `ws` and `cid` headers to gossip new content to instance
  - Tells instance about a location on the web where that CID may be found
- Configurable notify list (file)
  - Gossip new content to these locations
- Configurable origin allow list (file)
  - Only fetch content from these origins
  - Or allow all origins
- Configurable origin deny list (file)
  - Never fetch content from these origins, even if all origins are allowed